### PR TITLE
[SECURITY-1084] Remove dead link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,6 @@ FWFFR
 .. image:: https://img.shields.io/travis/GoodRx/fwffr.svg
         :target: https://travis-ci.org/GoodRx/fwffr
 
-.. image:: https://readthedocs.org/projects/fwffr/badge/?version=latest
-        :target: https://fwffr.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
-
 .. image:: https://pyup.io/repos/github/GoodRx/fwffr/shield.svg
      :target: https://pyup.io/repos/github/GoodRx/fwffr/
      :alt: Updates


### PR DESCRIPTION
There's a broken link that can be hijacked in the `README.rst`. This PR will remove it.