### PR TITLE
Add default message attribute

### DIFF
--- a/fwffr.py
+++ b/fwffr.py
@@ -8,6 +8,7 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
+__all__ = [
     'FixedLengthError',
     'FixedLengthUnknownRecordTypeError',
     'FixedLengthSeparatorError',

--- a/fwffr.py
+++ b/fwffr.py
@@ -8,7 +8,6 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
-__all__ = [
     'FixedLengthError',
     'FixedLengthUnknownRecordTypeError',
     'FixedLengthSeparatorError',
@@ -26,6 +25,9 @@ else:
 
 class FixedLengthError(ValueError):
     """ Base class for parsing errors """
+    
+    def __init__(self, message=None):
+        self.message = message
 
     def __str__(self):
         return self.message


### PR DESCRIPTION
The `message` attribute on ValueError has been deprecated since 2.6 and removed in Python 3. Explicitly add it ourselves for our subclasses. Fixes #2